### PR TITLE
Fix ShowPartition parsing when header starts with Index

### DIFF
--- a/infortrend/raidcmd_cli/cli_factory.py
+++ b/infortrend/raidcmd_cli/cli_factory.py
@@ -109,8 +109,14 @@ def strip_empty_in_list(list):
 
 
 def table_to_dict(table):
+    if not table:
+        return []
+
     tableHeader = table[0].split("  ")
     tableHeaderList = strip_empty_in_list(tableHeader)
+
+    if not tableHeaderList:
+        return []
 
     result = []
 
@@ -686,6 +692,15 @@ class ShowPartition(ShowCommand):
         self.command = "show part"
         self.start_key = "ID"
         self.show_noinit = ""
+
+    def detect_table_start_index(self, content):
+        for i in range(1, len(content)):
+            key = strip_empty_in_list(content[i].strip().split('  '))
+            if (key and key[0] in ('Index', 'ID') and
+                    'ID' in key and 'Name' in key):
+                return i
+
+        return -1
 
 
 class ShowSnapshot(ShowCommand):


### PR DESCRIPTION
# Fix `ShowPartition` parsing when the array header starts with `Index`

## Summary

This change fixes a parser regression in pristine `v2.1.5.4` on our `GS 2024UR` array.

The array returns `ShowPartition` output with a header that starts with:

```text
Index  ID  Name ...
```

Pristine `v2.1.5.4` does not parse that output robustly, which can leave `table_to_dict()` with an empty input and crash `cinder-volume` with `IndexError: list index out of range`.

## What changed

- Added empty-table and empty-header guards to `table_to_dict()`
- Added a `ShowPartition.detect_table_start_index()` override that accepts `Index  ID  Name ...`

## What did not change

- No partition naming logic was changed here
- No `1 GB` behavior was touched here

## Evidence

- Pristine image `infortrend-v2.1.5.4-vanilla1` failed a `10 GB` smoke test and left volume `8618e941-64f5-4dea-8bbd-b145603fea58` in `creating`
- The traceback ended in `cli_factory.py -> table_to_dict()` with `IndexError: list index out of range`
- The same environment works with this parser fix applied and completes `10 GB` create/delete successfully

## Related issue

- See the parser bug issue opened from the same environment
